### PR TITLE
Allow gcc-arm-embedded to be anywhere on system PATH

### DIFF
--- a/platform/arm.py
+++ b/platform/arm.py
@@ -1,12 +1,11 @@
 import os
 
-ARM_TOOLS_DIR = '/usr/local/gcc-arm-none-eabi-6-2017-q2-update/bin'
 PLATFORM_DIR = os.getcwd()
 
-compiler = ARM_TOOLS_DIR + '/arm-none-eabi-gcc'
-ranlib = ARM_TOOLS_DIR + '/arm-none-eabi-ranlib'
-objcopy = ARM_TOOLS_DIR + '/arm-none-eabi-objcopy'
-ar = ARM_TOOLS_DIR + '/arm-none-eabi-ar'
+compiler = 'arm-none-eabi-gcc'
+ranlib = 'arm-none-eabi-ranlib'
+objcopy = 'arm-none-eabi-objcopy'
+ar = 'arm-none-eabi-ar'
 
 arch_cflags = [
     '-mlittle-endian',
@@ -49,6 +48,8 @@ link_flags = [
 ]
 
 arm_env = Environment(
+    ENV = { 'PATH': os.environ['PATH'] },
+
     CC=compiler,
     CCFLAGS=cflags + arch_cflags + define_flags,
     CPPPATH=[],

--- a/platform/x86.py
+++ b/platform/x86.py
@@ -1,3 +1,5 @@
+import os
+
 cflags = [
     '-g',
     '-Os',
@@ -27,6 +29,8 @@ link_flags = [
 ]
 
 x86_env = Environment(
+    ENV = { 'PATH': os.environ['PATH'] },
+
     CC='gcc',
     CCFLAGS=cflags + define_flags,
     CPPPATH=[],


### PR DESCRIPTION
Scons uses its own PATH by default, so we have to explicitly use the system PATH (`os.environ['PATH']`). This allows us to not have to specify the location of the gcc-arm-embedded tools (which is different between backpack and packer boxes anyways), making it build without modification on my system.