### PR TITLE
Add mutex library

### DIFF
--- a/libraries/ms-common/inc/mutex.c
+++ b/libraries/ms-common/inc/mutex.c
@@ -1,0 +1,36 @@
+#include "mutex.h"
+
+StatusCode mutex_init(Mutex *mutex) {
+  mutex->handle = xSemaphoreCreateMutexStatic(&mutex->buffer);
+  if(mutex->handle == NULL) {
+    return STATUS_CODE_UNINITIALIZED;
+  } else {
+    return STATUS_CODE_OK;
+  }
+
+StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait) {
+  TickType_t ticks_to_wait;
+  if(ms_to_wait == BLOCK_INDEFINITELY) {
+    ticks_to_wait = portMAX_DELAY;
+  } else {
+    ticks_to_wait = pdMS_TO_TICKS(ms_to_wait); 
+  }
+  if (xSemaphoreTake(mutex->handle, ticks_to_wait) == pdFALSE) {
+    return STATUS_CODE_TIMEOUT;
+  }
+  return STATUS_CODE_OK;
+}
+
+StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller) {
+  bool result;
+  if(caller == MUTEX_CALLER_ISR) {
+    // Use ISR specific method
+    result = xSemaphoreGiveFromISR(mutex->handle);
+  } else {
+    result = xSemaphoreGive(mutex->handle);
+  }
+  if (result == pdFALSE) {
+    return STATUS_CODE_INTERNAL_ERROR;
+  }
+  return STATUS_CODE_OK;
+}

--- a/libraries/ms-common/inc/mutex.h
+++ b/libraries/ms-common/inc/mutex.h
@@ -9,10 +9,10 @@
 #define BLOCK_INDEFINITELY UINT16_MAX
 
 // Mutex handle is used to access Mutex
-// Mutex Objects must be declared statically 
+// Mutex Objects must be declared statically
 typedef struct Mutex {
   SemaphoreHandle_t handle;
-  StaticSemaphore_t buffer; 
+  StaticSemaphore_t buffer;
 } Mutex;
 
 // Initializes a mutex using provided static entity

--- a/libraries/ms-common/inc/mutex.h
+++ b/libraries/ms-common/inc/mutex.h
@@ -1,0 +1,35 @@
+#pragma once
+// Wrapper library for all mutex and semaphore usage
+
+#include "FreeRTOS.h"
+#include "smphr.h"
+#include "status.h"
+
+#define BLOCK_INDEFINITELY UINT16_MAX
+
+typedef enum MutexCaller {
+  MUTEX_CALLER_TASK = 0,
+  MUTEX_CALLER_ISR,
+}
+
+// Mutex handle is used to access Mutex
+// Mutex Objects must be declared statically 
+typedef struct Mutex {
+  SemaphoreHandle_t handle;
+  StaticSemaphore_t buffer; 
+} Mutex;
+
+// Initializes a mutex using provided static entity
+// Returns STATUS_CODE_OK on success, STATUS_CODE_UNINITIALIZED on failure
+StatusCode mutex_init(Mutex *mutex);
+
+// Locks a Mutex. The locking task is responsible for unlocking the mutex
+// Waits ms_to_wait milliseconds if mutex is already locked, then times out
+// Using BLOCK_INDEFINITELY will cause this method to wait forever on mutex becoming available
+// Returns STATUS_CODE_OK on success, STATUS_CODE_TIMEOUT on timeout
+StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait);
+
+// Unlocks a Mutex. The task which locks the mutex MUST also be the one to unlock it
+// Mutex type specifies whether the method is being called from a task or interrupt handler
+// Returns STATUS_CODE_OK on success, STATUS_CODE_INTERNTAL_ERROR on failure
+StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller);

--- a/libraries/ms-common/inc/mutex.h
+++ b/libraries/ms-common/inc/mutex.h
@@ -8,11 +8,6 @@
 
 #define BLOCK_INDEFINITELY UINT16_MAX
 
-typedef enum MutexCaller {
-  MUTEX_CALLER_TASK = 0,
-  MUTEX_CALLER_ISR,
-} MutexCaller;
-
 // Mutex handle is used to access Mutex
 // Mutex Objects must be declared statically 
 typedef struct Mutex {
@@ -33,5 +28,5 @@ StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait);
 // Unlocks a Mutex. The task which locks the mutex MUST also be the one to unlock it
 // Caller specifies whether the method is being called from a task or interrupt handler
 // higher_priority_task_woken informs the caller whether a higher priority task has become unblocked
-// Returns STATUS_CODE_OK on success, STATUS_CODE_INTERNTAL_ERROR on failure
-StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller, bool *higher_priority_task_woken);
+// Returns STATUS_CODE_OK on success, STATUS_CODE_INTERNAL_ERROR on failure
+StatusCode mutex_unlock(Mutex *mutex);

--- a/libraries/ms-common/inc/mutex.h
+++ b/libraries/ms-common/inc/mutex.h
@@ -1,8 +1,9 @@
 #pragma once
 // Wrapper library for all mutex and semaphore usage
+#include <stdbool.h>
 
 #include "FreeRTOS.h"
-#include "smphr.h"
+#include "semphr.h"
 #include "status.h"
 
 #define BLOCK_INDEFINITELY UINT16_MAX
@@ -10,7 +11,7 @@
 typedef enum MutexCaller {
   MUTEX_CALLER_TASK = 0,
   MUTEX_CALLER_ISR,
-}
+} MutexCaller;
 
 // Mutex handle is used to access Mutex
 // Mutex Objects must be declared statically 
@@ -30,6 +31,7 @@ StatusCode mutex_init(Mutex *mutex);
 StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait);
 
 // Unlocks a Mutex. The task which locks the mutex MUST also be the one to unlock it
-// Mutex type specifies whether the method is being called from a task or interrupt handler
+// Caller specifies whether the method is being called from a task or interrupt handler
+// higher_priority_task_woken informs the caller whether a higher priority task has become unblocked
 // Returns STATUS_CODE_OK on success, STATUS_CODE_INTERNTAL_ERROR on failure
-StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller);
+StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller, bool *higher_priority_task_woken);

--- a/libraries/ms-common/src/mutex.c
+++ b/libraries/ms-common/src/mutex.c
@@ -29,7 +29,6 @@ StatusCode mutex_unlock(Mutex *mutex) {
   if (mutex == NULL) {
       return STATUS_CODE_INVALID_ARGS;
   }
-
   if (xSemaphoreGive(mutex->handle) == pdFALSE) {
     return STATUS_CODE_INTERNAL_ERROR;
   }

--- a/libraries/ms-common/src/mutex.c
+++ b/libraries/ms-common/src/mutex.c
@@ -11,6 +11,9 @@ StatusCode mutex_init(Mutex *mutex) {
 
 StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait) {
   TickType_t ticks_to_wait;
+  if (mutex == NULL) {
+      return STATUS_CODE_INVALID_ARGS;
+  }
   if(ms_to_wait == BLOCK_INDEFINITELY) {
     ticks_to_wait = portMAX_DELAY;
   } else {
@@ -22,20 +25,12 @@ StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait) {
   return STATUS_CODE_OK;
 }
 
-StatusCode mutex_unlock(Mutex *mutex, MutexCaller caller, bool *higher_priority_task_woken) {
-  BaseType_t result, higher_priority_woken = pdFALSE;
-  if (higher_priority_task_woken == NULL) {
+StatusCode mutex_unlock(Mutex *mutex) {
+  if (mutex == NULL) {
       return STATUS_CODE_INVALID_ARGS;
   }
-  if(caller == MUTEX_CALLER_ISR) {
-    // Use ISR specific method
-    result = xSemaphoreGiveFromISR(mutex->handle, &higher_priority_woken);
-    *higher_priority_task_woken = higher_priority_woken;
-  } else {
-    *higher_priority_task_woken = false;
-    result = xSemaphoreGive(mutex->handle);
-  }
-  if (result == pdFALSE) {
+
+  if (xSemaphoreGive(mutex->handle) == pdFALSE) {
     return STATUS_CODE_INTERNAL_ERROR;
   }
   return STATUS_CODE_OK;

--- a/libraries/ms-common/src/mutex.c
+++ b/libraries/ms-common/src/mutex.c
@@ -2,7 +2,7 @@
 
 StatusCode mutex_init(Mutex *mutex) {
   mutex->handle = xSemaphoreCreateMutexStatic(&mutex->buffer);
-  if(mutex->handle == NULL) {
+  if (mutex->handle == NULL) {
     return STATUS_CODE_UNINITIALIZED;
   } else {
     return STATUS_CODE_OK;
@@ -12,12 +12,12 @@ StatusCode mutex_init(Mutex *mutex) {
 StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait) {
   TickType_t ticks_to_wait;
   if (mutex == NULL) {
-      return STATUS_CODE_INVALID_ARGS;
+    return STATUS_CODE_INVALID_ARGS;
   }
-  if(ms_to_wait == BLOCK_INDEFINITELY) {
+  if (ms_to_wait == BLOCK_INDEFINITELY) {
     ticks_to_wait = portMAX_DELAY;
   } else {
-    ticks_to_wait = pdMS_TO_TICKS(ms_to_wait); 
+    ticks_to_wait = pdMS_TO_TICKS(ms_to_wait);
   }
   if (xSemaphoreTake(mutex->handle, ticks_to_wait) == pdFALSE) {
     return STATUS_CODE_TIMEOUT;
@@ -27,7 +27,7 @@ StatusCode mutex_lock(Mutex *mutex, uint16_t ms_to_wait) {
 
 StatusCode mutex_unlock(Mutex *mutex) {
   if (mutex == NULL) {
-      return STATUS_CODE_INVALID_ARGS;
+    return STATUS_CODE_INVALID_ARGS;
   }
   if (xSemaphoreGive(mutex->handle) == pdFALSE) {
     return STATUS_CODE_INTERNAL_ERROR;

--- a/new_target.py
+++ b/new_target.py
@@ -54,12 +54,12 @@ def new_target(target_type, name):
     with the following structure:
 
     projects/libraries
-    └── name
-        ├── inc
-        ├── README.md
-        ├── config.json 
-        ├── src
-        └── test
+    - name
+        - inc
+        - README.md
+        - config.json 
+        - src
+        - test
 
     where config.json is required for the project or library to be valid.
 


### PR DESCRIPTION
Scons is giving me some grief right now for formatting/running, but the library compiles. I'll get to that before we merge.

Something to think about:
- Are we still planning to use status.h in the same way? I figured it was a good idea for now, but we can't exactly do a status_ok_or_return from a task, so may need to improve upon it in the future

(also got rid of the non-unicode characters from new_target)
