### PR TITLE
FWXV-68: Use mutexes in retarget.c for logging

### DIFF
--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -3,7 +3,6 @@
 
 #include <stdio.h>
 
-#include "mutex.h"
 #include "retarget_cfg.h"
 #include "stm32f0xx.h"
 
@@ -43,15 +42,12 @@ void retarget_init(void) {
 }
 
 int _write(int fd, char *ptr, int len) {
-  mutex_lock(&_write_mutex, BLOCK_INDEFINITELY);
-
   for (int i = 0; i < len; i++) {
     while (USART_GetFlagStatus(RETARGET_CFG_UART, USART_FLAG_TXE) == RESET) {
     }
     USART_SendData(RETARGET_CFG_UART, (uint8_t) * (ptr + i));
   }
 
-  mutex_unlock(&_write_mutex);
   return len;
 }
 

--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -3,9 +3,9 @@
 
 #include <stdio.h>
 
+#include "mutex.h"
 #include "retarget_cfg.h"
 #include "stm32f0xx.h"
-#include "mutex.h"
 
 static void prv_init_gpio(void) {
   RETARGET_CFG_UART_GPIO_ENABLE_CLK();

--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -25,8 +25,6 @@ static void prv_init_gpio(void) {
   GPIO_Init(RETARGET_CFG_UART_GPIO_PORT, &gpio_init);
 }
 
-static Mutex _write_mutex;
-
 void retarget_init(void) {
   RETARGET_CFG_UART_ENABLE_CLK();
   prv_init_gpio();
@@ -37,8 +35,6 @@ void retarget_init(void) {
   USART_Init(RETARGET_CFG_UART, &usart_init);
 
   USART_Cmd(RETARGET_CFG_UART, ENABLE);
-
-  mutex_init(&_write_mutex);
 }
 
 int _write(int fd, char *ptr, int len) {


### PR DESCRIPTION
Use mutex in _write instead of disabling interrupts.

I'm not sure how to test this? If there are ways please comment :)

EDIT: Logging was made thread-safe, so the use of mutexes was not necessary. Simply disabling interrupts should not result in any issues, cc Mitchell.