### PR TITLE
Add initial callback handler implementation

### DIFF
--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -41,3 +41,6 @@ void callback_init(TaskPriority priority);
 // Returns an Event - number between 0 and 31.
 // This Event will be needed in order to trigger the callback.
 Event register_callback(CallbackFn cb, void *context);
+
+// Unregisters the callback. Frees up space
+StatusCode cancel_callback(Event event);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -33,10 +33,9 @@ typedef void (*CallbackFn)(void *);
 DECLARE_TASK(callback_task);
 
 #define MAX_CALLBACKS 32
-#define ITEM_SIZE sizeof(CallbackFn)
 
 // Initialize callback handler.
-void callback_init(void);
+void callback_init(TaskPriority priority);
 
 // Register a callback function |cb| with generic argument |context|.
 // Returns an Event - number between 0 and 31.

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -24,8 +24,8 @@
 #include <stdlib.h>
 
 #include "FreeRTOS.h"
-#include "tasks.h"
 #include "notify.h"
+#include "tasks.h"
 
 // Each callback function must have the following signature.
 typedef void (*CallbackFn)(void *);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -1,0 +1,28 @@
+#pragma once
+// Callback handler library
+// TODO(daniel):
+// - add void *context to callback signature
+// - add comprehensive tests
+// - add documentation
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "FreeRTOS.h"
+#include "notify.h"
+#include "queue.h"
+#include "task.h"
+#include "tasks.h"
+
+typedef void (*callback)(void);
+
+DECLARE_TASK(callback_task);
+
+#define QUEUE_LENGTH 32
+#define MAX_CALLBACKS 32
+#define ITEM_SIZE sizeof(callback)
+
+void callback_init(void);
+
+Event register_callback(callback);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -25,6 +25,7 @@
 
 #include "FreeRTOS.h"
 #include "tasks.h"
+#include "notify.h"
 
 // Each callback function must have the following signature.
 typedef void (*CallbackFn)(void *);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -15,14 +15,13 @@
 #include "task.h"
 #include "tasks.h"
 
-typedef void (*callback)(void);
+typedef void (*CallbackFn)(void *);
 
 DECLARE_TASK(callback_task);
 
-#define QUEUE_LENGTH 32
 #define MAX_CALLBACKS 32
-#define ITEM_SIZE sizeof(callback)
+#define ITEM_SIZE sizeof(CallbackFn)
 
 void callback_init(void);
 
-Event register_callback(callback);
+Event register_callback(CallbackFn, void *context);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -19,6 +19,7 @@
 //    ...
 //      notify(callback_task->handle, event);
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,7 +29,9 @@
 #include "tasks.h"
 
 // Each callback function must have the following signature.
-typedef void (*CallbackFn)(void *);
+// Return value indicates whether or not the callback
+//    should be unregistered immediately after invocation.
+typedef bool (*CallbackFn)(void *);
 
 DECLARE_TASK(callback_task);
 
@@ -42,5 +45,9 @@ void callback_init(TaskPriority priority);
 // This Event will be needed in order to trigger the callback.
 Event register_callback(CallbackFn cb, void *context);
 
-// Unregisters the callback. Frees up space
-StatusCode cancel_callback(Event event);
+// Manually unregisters the callback.
+// This does not need to be done with a "one-shot" callback
+//   - i.e a CallbackFn which returns true will cancel automatically after being invoked.
+//
+// Pass in same cb and context as when registering the callback.
+StatusCode cancel_callback(CallbackFn cb, void *context);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -1,23 +1,23 @@
 #pragma once
 // Callback handler library. Can register up to 32 callbacks
-// 
+//
 // USAGE:
 //
 // Define a callback to register.
 //
-// 		void example_fn(void *context);
+//    void example_fn(void *context);
 //
 // Register the callback with any arguments passed as a context pointer.
 //
-// 		uint8_t my_number = 4;
-//		uint8_t *arg = &my_number;
-// 		Event event = register_callback(example_fn, arg)
+//    uint8_t my_number = 4;
+//    uint8_t *arg = &my_number;
+//    Event event = register_callback(example_fn, arg)
 //
 // Trigger the callback by notifying the callback handler task |callback_task|.
 // Pass the event returned by |register_callback| in the notification.
-// 		#include "notify.h"		
-//		...
-//			notify(callback_task->handle, event);
+//    #include "notify.h"
+//    ...
+//      notify(callback_task->handle, event);
 
 #include <stdint.h>
 #include <stdio.h>

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -1,20 +1,32 @@
 #pragma once
-// Callback handler library
-// TODO(daniel):
-// - add void *context to callback signature
-// - add comprehensive tests
-// - add documentation
+// Callback handler library. Can register up to 32 callbacks
+// 
+// USAGE:
+//
+// Define a callback to register.
+//
+// 		void example_fn(void *context);
+//
+// Register the callback with any arguments passed as a context pointer.
+//
+// 		uint8_t my_number = 4;
+//		uint8_t *arg = &my_number;
+// 		Event event = register_callback(example_fn, arg)
+//
+// Trigger the callback by notifying the callback handler task |callback_task|.
+// Pass the event returned by |register_callback| in the notification.
+// 		#include "notify.h"		
+//		...
+//			notify(callback_task->handle, event);
 
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "FreeRTOS.h"
-#include "notify.h"
-#include "queue.h"
-#include "task.h"
 #include "tasks.h"
 
+// Each callback function must have the following signature.
 typedef void (*CallbackFn)(void *);
 
 DECLARE_TASK(callback_task);
@@ -22,6 +34,10 @@ DECLARE_TASK(callback_task);
 #define MAX_CALLBACKS 32
 #define ITEM_SIZE sizeof(CallbackFn)
 
+// Initialize callback handler.
 void callback_init(void);
 
-Event register_callback(CallbackFn, void *context);
+// Register a callback function |cb| with generic argument |context|.
+// Returns an Event - number between 0 and 31.
+// This Event will be needed in order to trigger the callback.
+Event register_callback(CallbackFn cb, void *context);

--- a/libraries/ms-common/inc/callback_handler.h
+++ b/libraries/ms-common/inc/callback_handler.h
@@ -5,7 +5,10 @@
 //
 // Define a callback to register.
 //
-//    void example_fn(void *context);
+//    bool example_fn(void *context);
+//
+// If the callback returns true, it will unregister immediately after being called.
+// Otherwise, it will stay registered.
 //
 // Register the callback with any arguments passed as a context pointer.
 //
@@ -17,12 +20,11 @@
 // Pass the event returned by |register_callback| in the notification.
 //    #include "notify.h"
 //    ...
-//      notify(callback_task->handle, event);
+//      notify(callback_task, event);
+//
+// To manually unregister a callback, use the cancel_callback function.
 
 #include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "FreeRTOS.h"
 #include "notify.h"

--- a/libraries/ms-common/src/callback_handler.c
+++ b/libraries/ms-common/src/callback_handler.c
@@ -1,0 +1,71 @@
+#include "callback_handler.h"
+
+#include "log.h"
+#include "mutex.h"
+#include "notify.h"
+#include "status.h"
+
+static callback s_callback_storage[MAX_CALLBACKS] = { NULL };
+static Event s_first_available_event = 0;
+
+// Bit map of registered callbacks. A 1-bit represents the callback is registered.
+static uint32_t s_registered_callbacks = 0;
+
+static Mutex callback_mutex;
+
+void callback_init(void) {
+  StatusCode result = tasks_init_task(callback_task, TASK_PRIORITY(tskIDLE_PRIORITY + 1), NULL);
+  mutex_init(&callback_mutex);
+}
+
+Event prv_find_next_event() {
+  // This will happen if all bits in s_registered_callbacks are 1's.
+  // I.e. 32 callbacks registered, no more capacity.
+  if (~s_registered_callbacks == 0u) {
+    return INVALID_EVENT;
+  }
+  // Gets index of least significant 0 bit (first available event)
+  Event event = __builtin_ctz(~s_registered_callbacks);
+
+  return event;
+}
+
+StatusCode prv_run_callback(Event event) {
+  if (event > 31) {
+    return STATUS_CODE_INVALID_ARGS;
+  }
+
+  // Run callback
+  // ADD context field
+  s_callback_storage[event]();
+  s_callback_storage[event] = NULL;
+
+  // Clear bit in bitmask
+  s_registered_callbacks &= ~(1u << event);
+  LOG_DEBUG("Ran callback: %d, callbacks is: %08lx\n", event, s_registered_callbacks);
+
+  return STATUS_CODE_OK;
+}
+
+Event register_callback(callback cb) {
+  mutex_lock(&callback_mutex, BLOCK_INDEFINITELY);
+  Event event = prv_find_next_event();
+
+  // Set <event> bit in s_registered_callbacks to 1.
+  s_registered_callbacks |= 1u << event;
+  s_callback_storage[event] = cb;
+  mutex_unlock(&callback_mutex);
+
+  LOG_DEBUG("Registered callback: %d, callbacks is: %08lx\n", event, s_registered_callbacks);
+  return event;
+}
+
+TASK(callback_task, TASK_STACK_512) {
+  uint32_t notification = 0;
+  Event event = 0;
+  while (true) {
+    notify_wait(&notification, BLOCK_INDEFINITELY);
+    event_from_notification(&notification, &event);
+    prv_run_callback(event);
+  }
+}

--- a/libraries/ms-common/src/callback_handler.c
+++ b/libraries/ms-common/src/callback_handler.c
@@ -1,6 +1,7 @@
 #include "callback_handler.h"
 
 #include "log.h"
+#include "tasks.h"
 #include "notify.h"
 #include "status.h"
 
@@ -14,8 +15,8 @@ static Callback s_callback_storage[MAX_CALLBACKS];
 // Bitmap of registered callbacks. A 1-bit represents the callback is registered.
 static uint32_t s_registered_callbacks = 0;
 
-void callback_init(void) {
-  StatusCode result = tasks_init_task(callback_task, TASK_PRIORITY(tskIDLE_PRIORITY + 1), NULL);
+void callback_init(TaskPriority priority) {
+  StatusCode result = tasks_init_task(callback_task, priority, NULL);
 }
 
 // Helper function to find smallest event available to assign to a callback.

--- a/libraries/ms-common/src/callback_handler.c
+++ b/libraries/ms-common/src/callback_handler.c
@@ -76,7 +76,10 @@ TASK(callback_task, TASK_STACK_512) {
   Event event = 0;
   while (true) {
     notify_wait(&notification, BLOCK_INDEFINITELY);
-    event_from_notification(&notification, &event);
-    prv_trigger_callback(event);
+
+    while (event != 0) {
+      event_from_notification(&notification, &event);
+      prv_trigger_callback(event);
+    }
   }
 }

--- a/libraries/ms-common/src/callback_handler.c
+++ b/libraries/ms-common/src/callback_handler.c
@@ -7,7 +7,7 @@
 typedef struct {
   CallbackFn callback_fn;
   void *context;
-} Callback; 
+} Callback;
 
 static Callback s_callback_storage[MAX_CALLBACKS];
 
@@ -65,7 +65,7 @@ Event register_callback(CallbackFn cb, void *context) {
 
   // Set |event|th bit in s_registered_callbacks to 1.
   s_registered_callbacks |= 1u << event;
-  s_callback_storage[event] = (Callback){.callback_fn=cb, .context=context};
+  s_callback_storage[event] = (Callback){ .callback_fn = cb, .context = context };
 
   return event;
 }

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -70,5 +70,5 @@ TASK_TEST(test_callbacks, TASK_STACK_512) {
   delay_ms(1);
   tasks_init_task(callback_overflow, TASK_PRIORITY(1), NULL);
 
-  delay_ms(3000);
+  delay_ms(1000);
 }

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -2,6 +2,7 @@
 #include "delay.h"
 #include "log.h"
 #include "notify.h"
+#include "stdbool.h"
 #include "task_test_helpers.h"
 #include "tasks.h"
 #include "unity.h"
@@ -13,9 +14,12 @@ void setup_test(void) {
 
 void teardown_test(void) {}
 
-void print_num(void *context) {
+bool print_num(void *context) {
   uint8_t *num = context;
   LOG_DEBUG("%d has been printed.\n", *num);
+
+  // Do not cancel callback immediately after running
+  return false;
 }
 
 // Register maximum number of callbacks, then trigger all of them successively and unregister.
@@ -41,7 +45,7 @@ TASK(register_max_callbacks, TASK_STACK_512) {
   }
   delay_ms(5);
   for (uint8_t i = 0; i < MAX_CALLBACKS; ++i) {
-    TEST_ASSERT_EQUAL(cancel_callback(registered_events[i]), STATUS_CODE_OK);
+    TEST_ASSERT_EQUAL(cancel_callback(cb, test_numbers + i), STATUS_CODE_OK);
   }
 
   while (1) {
@@ -59,7 +63,7 @@ TASK(repeated_callback_trigger, TASK_STACK_512) {
     notify(callback_task->handle, event);
     delay_ms(1);
   }
-  TEST_ASSERT_EQUAL(cancel_callback(event), STATUS_CODE_OK);
+  TEST_ASSERT_EQUAL(cancel_callback(cb, num), STATUS_CODE_OK);
 
   free(num);
 

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -1,0 +1,42 @@
+#include "callback_handler.h"
+#include "delay.h"
+#include "log.h"
+#include "notify.h"
+#include "task_test_helpers.h"
+#include "tasks.h"
+#include "unity.h"
+
+void setup_test(void) {
+  log_init();
+  callback_init();
+}
+
+void teardown_test(void) {}
+
+void hello_world(void) {
+  LOG_DEBUG("Hello\n");
+  delay_ms(50);
+  LOG_DEBUG("world\n");
+}
+
+TASK(basic_callback, TASK_STACK_512) {
+  callback cb = &hello_world;
+
+  Event event = register_callback(cb);
+
+  LOG_DEBUG("Callback %d registered: waiting 300ms\n", event);
+
+  delay_ms(300);
+
+  notify(callback_task->handle, event);
+  while (true) {
+  }
+}
+
+TASK_TEST(test_callbacks, TASK_STACK_512) {
+  delay_ms(1);
+  LOG_DEBUG("test_callbacks\n");
+  tasks_init_task(basic_callback, TASK_PRIORITY(1), NULL);
+
+  delay_ms(1000);
+}

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -41,7 +41,8 @@ TASK(register_max_callbacks, TASK_STACK_512) {
     delay_ms(10);
   }
 
-  while (1);
+  while (1) {
+  }
 }
 
 // Try registering a callback when MAX_CALLBACKS has been reached
@@ -58,9 +59,9 @@ TASK(callback_overflow, TASK_STACK_512) {
 
   free(num);
 
-  while (1);
+  while (1) {
+  }
 }
-
 
 TASK_TEST(test_callbacks, TASK_STACK_512) {
   delay_ms(1);

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -40,7 +40,7 @@ TASK(register_max_callbacks, TASK_STACK_512) {
   delay_ms(50);
 
   for (uint8_t i = 0; i < MAX_CALLBACKS; ++i) {
-    notify(callback_task->handle, registered_events[i]);
+    notify(callback_task, registered_events[i]);
     // TEST_ASSERT(result);
   }
   delay_ms(5);
@@ -60,7 +60,7 @@ TASK(repeated_callback_trigger, TASK_STACK_512) {
   Event event = register_callback(cb, num);
 
   for (uint8_t i = 0; i < 10; ++i) {
-    notify(callback_task->handle, event);
+    notify(callback_task, event);
     delay_ms(1);
   }
   TEST_ASSERT_EQUAL(cancel_callback(cb, num), STATUS_CODE_OK);
@@ -80,7 +80,7 @@ TASK(callback_overflow, TASK_STACK_512) {
   TEST_ASSERT_EQUAL(event, INVALID_EVENT);
 
   // Try notifying callback task with invalid event
-  StatusCode status = notify(callback_task->handle, event);
+  StatusCode status = notify(callback_task, event);
   TEST_ASSERT_EQUAL(status, STATUS_CODE_INVALID_ARGS);
 
   free(num);

--- a/libraries/ms-common/test/test_callback_handler.c
+++ b/libraries/ms-common/test/test_callback_handler.c
@@ -13,30 +13,61 @@ void setup_test(void) {
 
 void teardown_test(void) {}
 
-void hello_world(void) {
-  LOG_DEBUG("Hello\n");
-  delay_ms(50);
-  LOG_DEBUG("world\n");
+void print_num(void *context) {
+  uint8_t *num = context;
+  LOG_DEBUG("%d has been printed.\n", *num);
 }
 
-TASK(basic_callback, TASK_STACK_512) {
-  callback cb = &hello_world;
+// Register maximum number of callbacks, then trigger all of them successively.
+TASK(register_max_callbacks, TASK_STACK_512) {
+  CallbackFn cb = &print_num;
 
-  Event event = register_callback(cb);
+  Event registered_events[MAX_CALLBACKS] = { 0 };
+  uint8_t test_numbers[MAX_CALLBACKS] = { 0 };
 
-  LOG_DEBUG("Callback %d registered: waiting 300ms\n", event);
-
-  delay_ms(300);
-
-  notify(callback_task->handle, event);
-  while (true) {
+  for (uint8_t i = 0; i < MAX_CALLBACKS; ++i) {
+    test_numbers[i] = i;
+    Event event = register_callback(cb, test_numbers + i);
+    registered_events[i] = event;
+    TEST_ASSERT_LESS_OR_EQUAL(MAX_CALLBACKS, event);
   }
+
+  // Wait for callback_overflow test to finish running
+  delay_ms(50);
+
+  for (uint8_t i = 0; i < MAX_CALLBACKS; ++i) {
+    StatusCode result = notify(callback_task->handle, registered_events[i]);
+    TEST_ASSERT(result);
+    delay_ms(10);
+  }
+
+  while (1);
 }
+
+// Try registering a callback when MAX_CALLBACKS has been reached
+// Callback slots get filled from register_max_callbacks task
+TASK(callback_overflow, TASK_STACK_512) {
+  uint32_t *num = malloc(sizeof(uint32_t));
+
+  Event event = register_callback(print_num, num);
+  TEST_ASSERT_EQUAL(event, INVALID_EVENT);
+
+  // Try notifying callback task with invalid event
+  StatusCode status = notify(callback_task->handle, event);
+  TEST_ASSERT_EQUAL(status, STATUS_CODE_INVALID_ARGS);
+
+  free(num);
+
+  while (1);
+}
+
 
 TASK_TEST(test_callbacks, TASK_STACK_512) {
   delay_ms(1);
   LOG_DEBUG("test_callbacks\n");
-  tasks_init_task(basic_callback, TASK_PRIORITY(1), NULL);
+  tasks_init_task(register_max_callbacks, TASK_PRIORITY(1), NULL);
+  delay_ms(1);
+  tasks_init_task(callback_overflow, TASK_PRIORITY(1), NULL);
 
-  delay_ms(1000);
+  delay_ms(3000);
 }


### PR DESCRIPTION
JIRA: https://uwmidsun.atlassian.net/browse/FWXV-93

## Description
Adds a task in `ms-common` for handling callbacks.

## Code Comments
 - Callback handler uses an array to store up to 32 callback function pointers
 - 32-bit bitmask used to track which callbacks have been registered

## Testing Notes
Still needs more comprehensive tests - there are two tests right there so far.

