### PR TITLE
FWXV-96 Created wait_tasks() and send_task_end()

### DIFF
--- a/libraries/ms-common/inc/tasks.h
+++ b/libraries/ms-common/inc/tasks.h
@@ -64,8 +64,8 @@
 // Parameter that will be used to initialize the end task semaphore.
 #define MAX_NUM_TASKS 15
 
-// Define timeout as max delay, which waits indefinitely
-#define WAIT_TASK_TIMEOUT portMAX_DELAY
+// Define wait timeout as 1 second, tasks cycle execution should not take longer than a second
+#define WAIT_TASK_TIMEOUT_MS 1000
 
 typedef UBaseType_t TaskPriority;
 
@@ -94,10 +94,10 @@ void tasks_start(void);
 // started.
 StatusCode tasks_init(void);
 
-// Waits for the defined number of tasks by repeatedly taking from semaphore that many times
-// When we take from the semaphore num_tasks amount of times, it means that many tasks
-// were completed
+// Attempts to take num_tasks items from end task semaphore, indicating the number of tasks
+// completed Returns STATUS_CODE_TIMEOUT if timeout occurs, STATUS_CODE_OK if num_tasks items taken
+// successfully
 StatusCode wait_tasks(uint16_t num_tasks);
 
 // A wrapper to give to the semaphore, to be called by tasks when they complete
-StatusCode send_task_end();
+StatusCode send_task_end(void);

--- a/libraries/ms-common/inc/tasks.h
+++ b/libraries/ms-common/inc/tasks.h
@@ -64,6 +64,9 @@
 // Parameter that will be used to initialize the end task semaphore.
 #define MAX_NUM_TASKS 15
 
+// Define timeout as max delay, which waits indefinitely
+#define WAIT_TASK_TIMEOUT portMAX_DELAY
+
 typedef UBaseType_t TaskPriority;
 
 // Represents everything we need to know to initialize a task.
@@ -90,3 +93,11 @@ void tasks_start(void);
 // Initialize the task module. Must be called before tasks are initialized or the scheduler is
 // started.
 StatusCode tasks_init(void);
+
+// Waits for the defined number of tasks by repeatedly taking from semaphore that many times
+// When we take from the semaphore num_tasks amount of times, it means that many tasks
+// were completed
+StatusCode wait_tasks(uint16_t num_tasks);
+
+// A wrapper to give to the semaphore, to be called by tasks when they complete
+StatusCode send_task_end();

--- a/libraries/ms-common/src/tasks.c
+++ b/libraries/ms-common/src/tasks.c
@@ -77,7 +77,7 @@ StatusCode tasks_init(void) {
 
 StatusCode wait_tasks(uint16_t num_tasks) {
   for (uint16_t i = 0; i < num_tasks; ++i) {
-    if (xSemaphoreTake(&s_end_task_sem, pdMS_TO_TICKS(WAIT_TASK_TIMEOUT_MS)) != pdTRUE) {
+    if (xSemaphoreTake(s_end_task_handle, pdMS_TO_TICKS(WAIT_TASK_TIMEOUT_MS)) != pdTRUE) {
       // Task took longer than 1 second for its execution cycle, return timeout
       return STATUS_CODE_TIMEOUT;
     }
@@ -86,7 +86,7 @@ StatusCode wait_tasks(uint16_t num_tasks) {
 }
 
 StatusCode send_task_end() {
-  if (xSemaphoreGive(&s_end_task_sem) != pdTRUE) {
+  if (xSemaphoreGive(s_end_task_handle) != pdTRUE) {
     // if giving to semaphore failed, we ran out of space in the buffer
     LOG_CRITICAL("CRITICAL: Out of buffer space in semaphore.");
     return STATUS_CODE_RESOURCE_EXHAUSTED;

--- a/libraries/ms-common/src/tasks.c
+++ b/libraries/ms-common/src/tasks.c
@@ -74,3 +74,22 @@ StatusCode tasks_init(void) {
     return STATUS_CODE_OK;
   }
 }
+
+StatusCode wait_tasks(uint16_t num_tasks) {
+  for (uint16_t i = 0; i < num_tasks; ++i) {
+    if (xSemaphoreTake(s_end_task_sem, WAIT_TASK_TIMEOUT) != pdTRUE) {
+      // WAIT_TASK_TIMEOUT is set to max dealy, which should wait indefinitely
+      // We should never actually return a timeout status code
+      return STATUS_CODE_TIMEOUT;
+    }
+  }
+  return STATUS_CODE_OK;
+}
+
+StatusCode send_task_end() {
+  if (xSemaphoreGive(s_end_task_sem) != pdTRUE) {
+    // if giving to semaphore failed, we ran out of space in the buffer
+    return STATUS_CODE_RESOURCE_EXHAUSTED;
+  }
+  return STATUS_CODE_OK;
+}

--- a/libraries/ms-common/src/tasks.c
+++ b/libraries/ms-common/src/tasks.c
@@ -77,9 +77,8 @@ StatusCode tasks_init(void) {
 
 StatusCode wait_tasks(uint16_t num_tasks) {
   for (uint16_t i = 0; i < num_tasks; ++i) {
-    if (xSemaphoreTake(s_end_task_sem, WAIT_TASK_TIMEOUT) != pdTRUE) {
-      // WAIT_TASK_TIMEOUT is set to max dealy, which should wait indefinitely
-      // We should never actually return a timeout status code
+    if (xSemaphoreTake(&s_end_task_sem, pdMS_TO_TICKS(WAIT_TASK_TIMEOUT_MS)) != pdTRUE) {
+      // Task took longer than 1 second for its execution cycle, return timeout
       return STATUS_CODE_TIMEOUT;
     }
   }
@@ -87,8 +86,9 @@ StatusCode wait_tasks(uint16_t num_tasks) {
 }
 
 StatusCode send_task_end() {
-  if (xSemaphoreGive(s_end_task_sem) != pdTRUE) {
+  if (xSemaphoreGive(&s_end_task_sem) != pdTRUE) {
     // if giving to semaphore failed, we ran out of space in the buffer
+    LOG_CRITICAL("CRITICAL: Out of buffer space in semaphore.");
     return STATUS_CODE_RESOURCE_EXHAUSTED;
   }
   return STATUS_CODE_OK;


### PR DESCRIPTION
Created wait_tasks() and send_task_end(). Both interact with the static semaphore.

- wait_tasks() will try to take from semaphore the defined amount of times and return OK.
- send_task_end() is a wrapper to give to semaphore, returns OK if successful, returns RESOURCE_EXHAUSTED if failed.