### PR TITLE
Add ads1015 files for x86

### DIFF
--- a/projects/pedal/inc/ads1015.h
+++ b/projects/pedal/inc/ads1015.h
@@ -1,0 +1,69 @@
+#pragma once
+// Module for interacting with the ADS1015 ADC over I2C.
+// I2C, GPIO, Interrupt, and Soft Timers should be initialized.
+//
+// The ADS1015 supports a conversion ready pin that we use as an interrupt.
+//
+// Uses a watchdog to detect if the ADS1015 has stopped triggering interrupts.
+// Although we use GPIO interrupts to detect conversion ready, it seems like
+// it's possible for us to miss it during bus glitching. This forces an
+// interrupt if we haven't triggered within a few conversion periods.
+#include <stdbool.h>
+#include "gpio.h"
+#include "i2c.h"
+#include "soft_timer.h"
+#include "status.h"
+
+// Arbitrary watchdog timeout period
+#define ADS1015_WATCHDOG_TIMEOUT_MS 100
+
+typedef enum {
+  ADS1015_ADDRESS_GND = 0,
+  ADS1015_ADDRESS_VDD,
+  ADS1015_ADDRESS_SDA,
+  ADS1015_ADDRESS_SCL,
+  NUM_ADS1015_ADDRESSES,
+} Ads1015Address;
+
+typedef enum {
+  ADS1015_CHANNEL_0 = 0,
+  ADS1015_CHANNEL_1,
+  ADS1015_CHANNEL_2,
+  ADS1015_CHANNEL_3,
+  NUM_ADS1015_CHANNELS,
+} Ads1015Channel;
+
+// The callback runs after each conversion from the channel.
+typedef void (*Ads1015Callback)(Ads1015Channel channel, void *context);
+
+typedef struct Ads1015Storage {
+  I2CPort i2c_port;
+  uint8_t i2c_addr;
+  GpioAddress ready_pin;
+  int16_t channel_readings[NUM_ADS1015_CHANNELS];
+  Ads1015Channel current_channel;
+  uint8_t channel_bitset;
+  uint8_t pending_channel_bitset;
+  Ads1015Callback channel_callback[NUM_ADS1015_CHANNELS];
+  void *callback_context[NUM_ADS1015_CHANNELS];
+
+  SoftTimerId watchdog_timer;
+  bool watchdog_kicked;
+  bool data_valid;
+} Ads1015Storage;
+
+// Initiates ads1015 by setting up registers and enabling ALRT/RDY Pin.
+StatusCode ads1015_init(Ads1015Storage *storage, I2CPort i2c_port, Ads1015Address i2c_addr,
+                        GpioAddress *ready_pin);
+
+// Enable/disables a channel, and registers a callback on the channel.
+StatusCode ads1015_configure_channel(Ads1015Storage *storage, Ads1015Channel channel, bool enable,
+                                     Ads1015Callback callback, void *context);
+
+// Reads raw 12 bit conversion results which are expressed in two's complement
+// format.
+StatusCode ads1015_read_raw(Ads1015Storage *storage, Ads1015Channel channel, int16_t *reading);
+
+// Reads conversion value in mVolt.
+StatusCode ads1015_read_converted(Ads1015Storage *storage, Ads1015Channel channel,
+                                  int16_t *reading);

--- a/projects/pedal/inc/ads1015.h
+++ b/projects/pedal/inc/ads1015.h
@@ -9,6 +9,7 @@
 // it's possible for us to miss it during bus glitching. This forces an
 // interrupt if we haven't triggered within a few conversion periods.
 #include <stdbool.h>
+
 #include "gpio.h"
 #include "i2c.h"
 #include "soft_timer.h"

--- a/projects/pedal/inc/ads1015_def.h
+++ b/projects/pedal/inc/ads1015_def.h
@@ -86,7 +86,7 @@
 // Setup for the config register's upper byte
 #define ADS1015_CONFIG_REGISTER_MSB(channel)                                 \
   (ADS1015_START_SINGLE_CONV | ADS1015_AIN(channel) | ADS1015_PGA_FSR_4096 | \
-   ADS1015_CONVERSION_MODE_SINGLE)
+ADS1015_CONVERSION_MODE_SINGLE)
 
 #define ADS1015_CONFIG_REGISTER_MSB_IDLE \
   (ADS1015_IDLE | ADS1015_AIN_0 | ADS1015_PGA_FSR_4096 | ADS1015_CONVERSION_MODE_SINGLE)
@@ -94,7 +94,7 @@
 // Setup for the config register's lower byte
 #define ADS1015_CONFIG_REGISTER_LSB(datarate)                                                    \
   ((datarate) | ADS1015_COMP_MODE_TRAD | ADS1015_COMP_POL_HIGH | ADS1015_COMP_LAT_NON_LATCHING | \
-   ADS1015_COMP_QUE_1_CONV)
+ADS1015_COMP_QUE_1_CONV)
 
 // These represent the full-scale range of ADS1015 scaling in mVolts.
 // They are used for calculating the LSB size, corresponding to PGA settings.

--- a/projects/pedal/inc/ads1015_def.h
+++ b/projects/pedal/inc/ads1015_def.h
@@ -86,7 +86,7 @@
 // Setup for the config register's upper byte
 #define ADS1015_CONFIG_REGISTER_MSB(channel)                                 \
   (ADS1015_START_SINGLE_CONV | ADS1015_AIN(channel) | ADS1015_PGA_FSR_4096 | \
-ADS1015_CONVERSION_MODE_SINGLE)
+  ADS1015_CONVERSION_MODE_SINGLE)
 
 #define ADS1015_CONFIG_REGISTER_MSB_IDLE \
   (ADS1015_IDLE | ADS1015_AIN_0 | ADS1015_PGA_FSR_4096 | ADS1015_CONVERSION_MODE_SINGLE)
@@ -94,7 +94,7 @@ ADS1015_CONVERSION_MODE_SINGLE)
 // Setup for the config register's lower byte
 #define ADS1015_CONFIG_REGISTER_LSB(datarate)                                                    \
   ((datarate) | ADS1015_COMP_MODE_TRAD | ADS1015_COMP_POL_HIGH | ADS1015_COMP_LAT_NON_LATCHING | \
-ADS1015_COMP_QUE_1_CONV)
+  ADS1015_COMP_QUE_1_CONV)
 
 // These represent the full-scale range of ADS1015 scaling in mVolts.
 // They are used for calculating the LSB size, corresponding to PGA settings.

--- a/projects/pedal/inc/ads1015_def.h
+++ b/projects/pedal/inc/ads1015_def.h
@@ -1,0 +1,124 @@
+#pragma once
+// This is an internal file for ads1015 module that provides macros mostly for
+// register setup.
+
+// Base I2C address(GND) of ADS1015. Summing it with Ads1015Address enum gives
+// an actual I2CAddress. From section 8.5.1.1 of the datasheet.
+#define ADS1015_I2C_BASE_ADDRESS ((uint8_t)0x48)
+
+// Register address pointers, used for switching between registers.
+// From section 8.6.1 of the datasheet.
+#define ADS1015_ADDRESS_POINTER_CONV ((uint8_t)0x0)
+#define ADS1015_ADDRESS_POINTER_CONFIG ((uint8_t)0x1)
+#define ADS1015_ADDRESS_POINTER_LO_THRESH ((uint8_t)0x2)
+#define ADS1015_ADDRESS_POINTER_HI_THRESH ((uint8_t)0x3)
+
+// Upper and Lower bytes of Hi_thresh and Lo_thresh registers.
+// The most significant bit of both registers has been set accordingly to enable
+// ALRT/RDY pin From section 8.6.4 of the datasheet.
+#define ADS1015_LO_THRESH_REGISTER_MSB ((uint8_t)0x0)
+#define ADS1015_LO_THRESH_REGISTER_LSB ((uint8_t)0x0)
+#define ADS1015_HI_THRESH_REGISTER_MSB ((uint8_t)0xFF)
+#define ADS1015_HI_THRESH_REGISTER_LSB ((uint8_t)0xFF)
+
+// ********* The following bytes are fields for the config register
+// *********************
+// ********* From section 8.6.3 of the datasheet
+// ****************************************
+
+// Starts single conversion when in powerdown state.
+#define ADS1015_START_SINGLE_CONV ((uint8_t)0x1 << 7)
+// Does not start a conversion.
+#define ADS1015_IDLE ((uint8_t)0x0)
+
+// Bytes for setting channels
+#define ADS1015_AIN(channel) (((channel) + 0x4) << 4)
+#define ADS1015_AIN_0 ((uint8_t)0x4 << 4)
+#define ADS1015_AIN_1 ((uint8_t)0x5 << 4)
+#define ADS1015_AIN_2 ((uint8_t)0x6 << 4)
+#define ADS1015_AIN_3 ((uint8_t)0x7 << 4)
+
+// These bytes set the FSR of the programmable gain amplifier.
+#define ADS1015_PGA_FSR_6144 ((uint8_t)0x0 << 1)  // ±6.144 V
+#define ADS1015_PGA_FSR_4096 ((uint8_t)0x1 << 1)  // ±4.096 V (default)
+#define ADS1015_PGA_FSR_2048 ((uint8_t)0x2 << 1)  // ±2.048 V
+#define ADS1015_PGA_FSR_1024 ((uint8_t)0x3 << 1)  // ±1.024 V
+#define ADS1015_PGA_FSR_512 ((uint8_t)0x4 << 1)   // ±0.512 V
+#define ADS1015_PGA_FSR_256 ((uint8_t)0x5 << 1)   // ±0.256 V
+
+// Conversion mode (single or continuous)
+#define ADS1015_CONVERSION_MODE_CONT ((uint8_t)0x0)
+#define ADS1015_CONVERSION_MODE_SINGLE ((uint8_t)0x1)  // default
+
+// Data sampling rate of the adc
+#define ADS1015_DATA_RATE_128 ((uint8_t)0x0 << 5)   //  128 SPS
+#define ADS1015_DATA_RATE_250 ((uint8_t)0x1 << 5)   //  250 SPS
+#define ADS1015_DATA_RATE_490 ((uint8_t)0x2 << 5)   //  490 SPS
+#define ADS1015_DATA_RATE_920 ((uint8_t)0x3 << 5)   //  920 SPS
+#define ADS1015_DATA_RATE_1600 ((uint8_t)0x4 << 5)  // 1600 SPS
+#define ADS1015_DATA_RATE_2400 ((uint8_t)0x5 << 5)  // 2400 SPS
+#define ADS1015_DATA_RATE_3300 ((uint8_t)0x6 << 5)  // 3300 SPS
+
+// Time between each conversion in microseconds.
+#define ADS1015_CONVERSION_TIME_US_1600_SPS (1000000 / 1600)
+
+// Comparator operating mode
+#define ADS1015_COMP_MODE_TRAD ((uint8_t)0x0 << 4)  // default
+#define ADS1015_COMP_MODE_WINDOW ((uint8_t)0x1 << 4)
+
+// Polarity of the ALERT/RDY pin (active low or active high)
+#define ADS1015_COMP_POL_LOW ((uint8_t)0x0 << 3)
+#define ADS1015_COMP_POL_HIGH ((uint8_t)0x1 << 3)
+
+// Latching comparator
+#define ADS1015_COMP_LAT_NON_LATCHING ((uint8_t)0x0 << 2)
+#define ADS1015_COMP_LAT_LATCHING ((uint8_t)0x1 << 2)
+
+// Comparator queue and disable
+#define ADS1015_COMP_QUE_1_CONV ((uint8_t)0x0)  // Assert after one conversion
+#define ADS1015_COMP_QUE_2_CONV ((uint8_t)0x1)  // Assert after two conversion
+#define ADS1015_COMP_QUE_4_CONV ((uint8_t)0x2)  // Assert after four conversion
+#define ADS1015_COMP_QUE_DISABLE_COMP \
+  ((uint8_t)0x3)  // Disable comparator and set ALERT/RDY pin to high-impedance
+
+// **************************************************************************************
+
+// Setup for the config register's upper byte
+#define ADS1015_CONFIG_REGISTER_MSB(channel)                                 \
+  (ADS1015_START_SINGLE_CONV | ADS1015_AIN(channel) | ADS1015_PGA_FSR_4096 | \
+   ADS1015_CONVERSION_MODE_SINGLE)
+
+#define ADS1015_CONFIG_REGISTER_MSB_IDLE \
+  (ADS1015_IDLE | ADS1015_AIN_0 | ADS1015_PGA_FSR_4096 | ADS1015_CONVERSION_MODE_SINGLE)
+
+// Setup for the config register's lower byte
+#define ADS1015_CONFIG_REGISTER_LSB(datarate)                                                    \
+  ((datarate) | ADS1015_COMP_MODE_TRAD | ADS1015_COMP_POL_HIGH | ADS1015_COMP_LAT_NON_LATCHING | \
+   ADS1015_COMP_QUE_1_CONV)
+
+// These represent the full-scale range of ADS1015 scaling in mVolts.
+// They are used for calculating the LSB size, corresponding to PGA settings.
+// From section 8.3.3 of the datasheet.
+// Mult. by 2 corresponds to the range from -FS to +FS.
+#define ADS1015_FSR_6144 (6144 * 2)
+#define ADS1015_FSR_4096 (4096 * 2)
+#define ADS1015_FSR_2048 (2048 * 2)
+#define ADS1015_FSR_1024 (1024 * 2)
+#define ADS1015_FSR_512 (512 * 2)
+#define ADS1015_FSR_256 (256 * 2)
+#define ADS1015_CURRENT_FSR ADS1015_FSR_4096  // make sure PGA is set up accordingly
+
+// The division factor for calculating LSB size from FSR in mVolt
+#define ADS1015_NUMBER_OF_CODES (1 << 12)
+
+// This is used for removing 4 lsb's of the conversion register
+// as they are not part of the conversion result.
+// From section 8.6.2 of the datasheet.
+#define ADS1015_NUM_RESERVED_BITS_CONV_REG 4
+
+// This is stored as the reading for any disabled channel.
+#define ADS1015_DISABLED_CHANNEL_READING INT16_MAX
+
+#define ADS1015_BITSET_EMPTY 0
+
+#define ADS1015_READ_UNSUCCESSFUL INT16_MIN

--- a/projects/pedal/inc/ads1015_def.h
+++ b/projects/pedal/inc/ads1015_def.h
@@ -86,7 +86,7 @@
 // Setup for the config register's upper byte
 #define ADS1015_CONFIG_REGISTER_MSB(channel)                                 \
   (ADS1015_START_SINGLE_CONV | ADS1015_AIN(channel) | ADS1015_PGA_FSR_4096 | \
-  ADS1015_CONVERSION_MODE_SINGLE)
+   ADS1015_CONVERSION_MODE_SINGLE) // NOLINT
 
 #define ADS1015_CONFIG_REGISTER_MSB_IDLE \
   (ADS1015_IDLE | ADS1015_AIN_0 | ADS1015_PGA_FSR_4096 | ADS1015_CONVERSION_MODE_SINGLE)
@@ -94,7 +94,7 @@
 // Setup for the config register's lower byte
 #define ADS1015_CONFIG_REGISTER_LSB(datarate)                                                    \
   ((datarate) | ADS1015_COMP_MODE_TRAD | ADS1015_COMP_POL_HIGH | ADS1015_COMP_LAT_NON_LATCHING | \
-  ADS1015_COMP_QUE_1_CONV)
+   ADS1015_COMP_QUE_1_CONV) // NOLINT
 
 // These represent the full-scale range of ADS1015 scaling in mVolts.
 // They are used for calculating the LSB size, corresponding to PGA settings.

--- a/projects/pedal/inc/ads1015_def.h
+++ b/projects/pedal/inc/ads1015_def.h
@@ -86,7 +86,7 @@
 // Setup for the config register's upper byte
 #define ADS1015_CONFIG_REGISTER_MSB(channel)                                 \
   (ADS1015_START_SINGLE_CONV | ADS1015_AIN(channel) | ADS1015_PGA_FSR_4096 | \
-   ADS1015_CONVERSION_MODE_SINGLE) // NOLINT
+   ADS1015_CONVERSION_MODE_SINGLE)  // NOLINT
 
 #define ADS1015_CONFIG_REGISTER_MSB_IDLE \
   (ADS1015_IDLE | ADS1015_AIN_0 | ADS1015_PGA_FSR_4096 | ADS1015_CONVERSION_MODE_SINGLE)
@@ -94,7 +94,7 @@
 // Setup for the config register's lower byte
 #define ADS1015_CONFIG_REGISTER_LSB(datarate)                                                    \
   ((datarate) | ADS1015_COMP_MODE_TRAD | ADS1015_COMP_POL_HIGH | ADS1015_COMP_LAT_NON_LATCHING | \
-   ADS1015_COMP_QUE_1_CONV) // NOLINT
+   ADS1015_COMP_QUE_1_CONV)  // NOLINT
 
 // These represent the full-scale range of ADS1015 scaling in mVolts.
 // They are used for calculating the LSB size, corresponding to PGA settings.

--- a/projects/pedal/src/ads1015.c
+++ b/projects/pedal/src/ads1015.c
@@ -5,9 +5,10 @@
 // rotation of the channels is implemented using bitsets. The readings are just
 // a arbitrary value.
 #include "ads1015.h"
-#include <string.h>
-#include "FreeRTOS.h"
 
+#include <string.h>
+
+#include "FreeRTOS.h"
 #include "ads1015_def.h"
 #include "soft_timer.h"
 

--- a/projects/pedal/src/ads1015.c
+++ b/projects/pedal/src/ads1015.c
@@ -1,0 +1,125 @@
+// This module emulates the behavior of ADS1015 on x86.
+// Instead of having interrupts raised by the device once a channel finishes
+// conversion, there is a soft timer with prv_timer_callback that is called
+// periodically to update channel readings and switch to the next channel. The
+// rotation of the channels is implemented using bitsets. The readings are just
+// a arbitrary value.
+#include "ads1015.h"
+#include <string.h>
+#include "FreeRTOS.h"
+
+#include "ads1015_def.h"
+#include "soft_timer.h"
+
+#define ADS1015_CHANNEL_UPDATE_PERIOD_US ADS1015_CONVERSION_TIME_US_1600_SPS
+#define ADS1015_CHANNEL_ARBITRARY_READING 0
+
+static SoftTimer s_timer;
+static Ads1015Storage *context;
+
+// Checks if a channel is enabled (true) or disabled (false).
+static bool prv_channel_is_enabled(Ads1015Storage *storage, Ads1015Channel channel) {
+  return ((storage->channel_bitset & (1 << channel)) != 0);
+}
+
+// Updates the channel_bitset when a channel is enabled/disabled.
+static void prv_mark_channel_enabled(Ads1015Channel channel, bool enable, uint8_t *channel_bitset) {
+  if (enable) {
+    *channel_bitset |= (1 << channel);
+  } else {
+    *channel_bitset &= ~(1 << channel);
+  }
+}
+
+// Sets the current channel of the storage.
+static StatusCode prv_set_channel(Ads1015Storage *storage, Ads1015Channel channel) {
+  if (channel >= NUM_ADS1015_CHANNELS) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+
+  storage->current_channel = channel;
+  return STATUS_CODE_OK;
+}
+
+// Periodically calls channels' callbacks imitating the interrupt behavior.
+static void prv_timer_callback(SoftTimerId id) {
+  Ads1015Storage *storage = context;
+  Ads1015Channel current_channel = storage->current_channel;
+
+  if (prv_channel_is_enabled(storage, current_channel)) {
+    storage->channel_readings[current_channel] = ADS1015_CHANNEL_ARBITRARY_READING;
+
+    // Runs the users callback if not NULL.
+    if (storage->channel_callback[current_channel] != NULL) {
+      storage->channel_callback[current_channel](current_channel,
+                                                 storage->callback_context[current_channel]);
+    }
+  }
+  // Disable the channel on the pending bitset.
+  prv_mark_channel_enabled(current_channel, false, &storage->pending_channel_bitset);
+  // Reset the pending bitset once gone through a cycle of channel rotation.
+  if (storage->pending_channel_bitset == ADS1015_BITSET_EMPTY) {
+    storage->pending_channel_bitset = storage->channel_bitset;
+  }
+  // Obtain the next enabled channel.
+  current_channel = (Ads1015Channel)(__builtin_ffs(storage->pending_channel_bitset) - 1);
+  // Update so that the ADS1015 reads from the next channel.
+  prv_set_channel(storage, current_channel);
+  soft_timer_start(ADS1015_CHANNEL_UPDATE_PERIOD_US, prv_timer_callback, &s_timer);
+}
+
+// Inits the storage for ADS1015 and starts the soft timer.
+StatusCode ads1015_init(Ads1015Storage *storage, I2CPort i2c_port, Ads1015Address i2c_addr,
+                        GpioAddress *ready_pin) {
+  if (storage == NULL || ready_pin == NULL) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  memset(storage, 0, sizeof(Ads1015Storage));
+  for (Ads1015Channel channel = 0; channel < NUM_ADS1015_CHANNELS; channel++) {
+    storage->channel_readings[channel] = ADS1015_DISABLED_CHANNEL_READING;
+  }
+  context = storage;
+  return soft_timer_start(ADS1015_CHANNEL_UPDATE_PERIOD_US, prv_timer_callback, &s_timer);
+}
+
+// Enable/disables a channel, and sets a callback for the channel.
+StatusCode ads1015_configure_channel(Ads1015Storage *storage, Ads1015Channel channel, bool enable,
+                                     Ads1015Callback callback, void *context) {
+  if (storage == NULL || channel >= NUM_ADS1015_CHANNELS) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  prv_mark_channel_enabled(channel, enable, &storage->channel_bitset);
+  storage->pending_channel_bitset = storage->channel_bitset;
+  storage->channel_callback[channel] = callback;
+  storage->callback_context[channel] = context;
+
+  if (!enable) {
+    storage->channel_readings[channel] = ADS1015_DISABLED_CHANNEL_READING;
+  }
+  return STATUS_CODE_OK;
+}
+
+// Reads raw results from the storage.
+StatusCode ads1015_read_raw(Ads1015Storage *storage, Ads1015Channel channel, int16_t *reading) {
+  if (channel >= NUM_ADS1015_CHANNELS || storage == NULL || reading == NULL ||
+      !prv_channel_is_enabled(storage, channel)) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+
+  *reading = storage->channel_readings[channel];
+  return STATUS_CODE_OK;
+}
+
+// Reads conversion value in mVolt.
+StatusCode ads1015_read_converted(Ads1015Storage *storage, Ads1015Channel channel,
+                                  int16_t *reading) {
+  if (channel >= NUM_ADS1015_CHANNELS || storage == NULL || reading == NULL ||
+      !prv_channel_is_enabled(storage, channel)) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+
+  int16_t raw_reading = ADS1015_READ_UNSUCCESSFUL;
+  status_ok_or_return(ads1015_read_raw(storage, channel, &raw_reading));
+  *reading = (raw_reading * ADS1015_CURRENT_FSR) / ADS1015_NUMBER_OF_CODES;
+  return STATUS_CODE_OK;
+}


### PR DESCRIPTION
This is nearly the same as the files for x86 on FWXIV, just had to change the soft timer to work with the updated library.