### PR TITLE
FWXV-196: pca9555 tests

### DIFF
--- a/libraries/ms-common/src/x86/i2c.c
+++ b/libraries/ms-common/src/x86/i2c.c
@@ -3,12 +3,45 @@
 #include "log.h"
 #include "stdio.h"
 
+// Used to protect I2C resources
+// All data tx'd and rx'd through queue
+// Transactions on each I2C port protected by Mutex
+typedef struct {
+  uint8_t buf[I2C_MAX_NUM_DATA];
+  Queue queue;
+  Mutex mutex;
+} I2CBuffer;
+
+typedef enum I2CMode {
+  I2C_MODE_TRANSMIT = 0,
+  I2C_MODE_RECEIVE,
+  NUM_I2C_MODES,
+} I2CMode;
+
+typedef struct {
+  I2CSettings settings;     // I2C Config
+  I2CBuffer i2c_buf;        // RTOS data structures
+  bool curr_mode;           // Mode used in current transxn
+  I2CAddress current_addr;  // Addr used in current transxn
+} I2CPortData;
+
+static I2CPortData s_port[NUM_I2C_PORTS] = {
+  [I2C_PORT_1] = {},
+  [I2C_PORT_2] = {},
+};
+
 StatusCode i2c_init(I2CPort i2c, const I2CSettings *settings) {
   if (i2c >= NUM_I2C_PORTS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C port.");
   } else if (settings->speed >= NUM_I2C_SPEEDS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C speed.");
   }
+
+  s_port[i2c].i2c_buf.queue.num_items = I2C_MAX_NUM_DATA;
+  s_port[i2c].i2c_buf.queue.item_size = sizeof(uint8_t);
+  s_port[i2c].i2c_buf.queue.storage_buf = s_port[i2c].i2c_buf.buf;
+  status_ok_or_return(queue_init(&s_port[i2c].i2c_buf.queue));
+
   return STATUS_CODE_OK;
 }
 
@@ -16,9 +49,17 @@ StatusCode i2c_read(I2CPort i2c, I2CAddress addr, uint8_t *rx_data, size_t rx_le
   if (i2c >= NUM_I2C_PORTS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C port.");
   }
-  for (size_t i = 0; i < rx_len; i++) {
-    // Insert dummy data
-    rx_data[i] = i % 2;
+
+  s_port[i2c].current_addr = addr;
+  s_port[i2c].curr_mode = I2C_MODE_RECEIVE;
+
+  // Receive data from queue
+  // If less than requested is received, an error in the transaction has occurred
+  for (size_t rx = 0; rx < rx_len; rx++) {
+    if (queue_receive(&s_port[i2c].i2c_buf.queue, &rx_data[rx], 0)) {
+      queue_reset(&s_port[i2c].i2c_buf.queue);
+      return STATUS_CODE_INTERNAL_ERROR;
+    }
   }
   return STATUS_CODE_OK;
 }
@@ -27,6 +68,19 @@ StatusCode i2c_write(I2CPort i2c, I2CAddress addr, uint8_t *tx_data, size_t tx_l
   if (i2c >= NUM_I2C_PORTS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C port.");
   }
+
+  // Copy data into queue
+  for (size_t tx = 0; tx < tx_len; tx++) {
+    if (queue_send(&s_port[i2c].i2c_buf.queue, &tx_data[tx], 0)) {
+      queue_reset(&s_port[i2c].i2c_buf.queue);
+      return STATUS_CODE_RESOURCE_EXHAUSTED;
+    }
+  }
+
+  // Store address for this transaction
+  s_port[i2c].current_addr = addr;
+  s_port[i2c].curr_mode = I2C_MODE_TRANSMIT;
+
   return STATUS_CODE_OK;
 }
 
@@ -35,10 +89,9 @@ StatusCode i2c_read_reg(I2CPort i2c, I2CAddress addr, uint8_t reg, uint8_t *rx_d
   if (i2c >= NUM_I2C_PORTS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C port.");
   }
-  for (size_t i = 0; i < rx_len; i++) {
-    // Insert dummy data
-    rx_data[i] = i % 2;
-  }
+  uint8_t reg_to_read = reg;
+  status_ok_or_return(i2c_write(i2c, addr, &reg_to_read, sizeof(reg)));
+  status_ok_or_return(i2c_read(i2c, addr, rx_data, rx_len));
   return STATUS_CODE_OK;
 }
 
@@ -47,5 +100,9 @@ StatusCode i2c_write_reg(I2CPort i2c, I2CAddress addr, uint8_t reg, uint8_t *tx_
   if (i2c >= NUM_I2C_PORTS) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid I2C port.");
   }
+
+  uint8_t reg_to_write = reg;
+  status_ok_or_return(i2c_write(i2c, addr, &reg_to_write, sizeof(reg)));
+  status_ok_or_return(i2c_write(i2c, addr, tx_data, tx_len));
   return STATUS_CODE_OK;
 }

--- a/libraries/ms-drivers/test/test_pca9555_gpio_expander.c
+++ b/libraries/ms-drivers/test/test_pca9555_gpio_expander.c
@@ -1,0 +1,95 @@
+#include <stdbool.h>
+#include <unistd.h>
+
+#include "delay.h"
+#include "gpio.h"
+#include "log.h"
+#include "pca9555_gpio_expander.h"
+#include "semaphore.h"
+#include "status.h"
+#include "task_test_helpers.h"
+#include "tasks.h"
+#include "unity.h"
+
+#define MOCK_I2C_ADDRESS 0b01010101
+#define MOCK_I2C_OUT_PIN PCA9555_PIN_IO0_4
+#define MOCK_I2C_IN_PIN PCA9555_PIN_IO0_1
+#define MOCK_REG 0b00100011
+
+static I2CSettings i2c_settings = { .scl = { .port = GPIO_PORT_A, .pin = 5 },
+                                    .sda = { .port = GPIO_PORT_A, .pin = 4 },
+                                    .speed = I2C_SPEED_STANDARD };
+
+static I2CPort i2c_port = I2C_PORT_1;
+static Pca9555GpioAddress pca9555_out_address = { .i2c_address = MOCK_I2C_ADDRESS,
+                                                  .pin = MOCK_I2C_OUT_PIN };
+static Pca9555GpioAddress pca9555_in_address = { .i2c_address = MOCK_I2C_ADDRESS,
+                                                 .pin = MOCK_I2C_IN_PIN };
+static Pca9555GpioSettings pca9555_out_settings = { .direction = PCA9555_GPIO_DIR_OUT,
+                                                    .state = PCA9555_GPIO_STATE_LOW };
+static Pca9555GpioSettings pca9555_in_settings = { .direction = PCA9555_GPIO_DIR_IN,
+                                                   .state = PCA9555_GPIO_STATE_LOW };
+
+// Gpio operations from different tasks should be
+// protected by a mutex
+static Mutex s_pca9555_expander;
+
+void setup_test(void) {
+  log_init();
+  gpio_init();
+  gpio_it_init();
+
+  i2c_init(i2c_port, &i2c_settings);
+  pca9555_gpio_init(i2c_port, MOCK_I2C_ADDRESS);
+}
+
+void teardown_test(void) {}
+
+TEST_IN_TASK
+
+void test_gpio_set_state(void) {
+  Pca9555GpioState state = PCA9555_GPIO_STATE_LOW;
+  StatusCode status;
+  uint8_t data;
+  status = pca9555_gpio_set_state(&pca9555_out_address, PCA9555_GPIO_STATE_HIGH);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+
+  // reading the reg address. Reg address should be 0x01 (OUTPUT01) for pins 0-7
+  status = i2c_read(i2c_port, MOCK_I2C_ADDRESS, &data, 1);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+  TEST_ASSERT_EQUAL(0x02, data);
+
+  // reading reg content. Reg content should have bit 4 turned on since mock pin is pin 4.
+  status = i2c_read(i2c_port, MOCK_I2C_ADDRESS, &data, 1);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+  TEST_ASSERT_EQUAL((0x02 | 1 << MOCK_I2C_OUT_PIN), data);
+}
+
+void test_gpio_get_state(void) {
+  Pca9555GpioState state = PCA9555_GPIO_STATE_LOW;
+  StatusCode status;
+  uint8_t data;
+
+  status = pca9555_gpio_get_state(&pca9555_in_address, &state);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+  TEST_ASSERT_EQUAL(PCA9555_GPIO_STATE_LOW, state);
+}
+
+void test_gpio_toggle_state(void) {
+  Pca9555GpioState state = PCA9555_GPIO_STATE_LOW;
+  StatusCode status;
+  uint8_t data;
+
+  status = pca9555_gpio_toggle_state(&pca9555_out_address);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+
+  // reading the reg address. Reg address should be 0x01 (OUTPUT01) for pins 0-7
+  status = i2c_read(i2c_port, MOCK_I2C_ADDRESS, &data, 1);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+  TEST_ASSERT_EQUAL(0x02, data);
+
+  // reading reg content. Reg content should have bit 4 turned on since mock pin is pin 4.
+  status = i2c_read(i2c_port, MOCK_I2C_ADDRESS, &data, 1);
+  TEST_ASSERT_EQUAL(STATUS_CODE_OK, status);
+  TEST_ASSERT_EQUAL(1 << MOCK_I2C_OUT_PIN, data);
+}


### PR DESCRIPTION
Added a couple of tests to show the general structure I'm following. I plan to add more.

I added a queue in the /x86/i2c library. This is based off the implementation in the arm version.

The issue with testing currently is that when reading/writing a register from i2c, it first writes the reg address and then reads from i2c. So if we use a dummy queue or a dummy variable, it will write the reg address to it, and then we will be reading that dummy value instead of any other pre-set value.