### PR TITLE
Fault task

### DIFF
--- a/libraries/ms-common/inc/fault.h
+++ b/libraries/ms-common/inc/fault.h
@@ -1,0 +1,25 @@
+#include "status.h"
+#include "stdint.h"
+
+#define WATCHDOG_MAX_FAULTS 5
+
+typedef void (*FaultHandler)(void);
+
+typedef struct {
+  // Faults to watch
+  // Faults should always be zero for no fault and non-zero when action is needed
+  uint8_t faults[WATCHDOG_MAX_FAULTS];
+  uint8_t num_faults;
+
+  // Messages to watch
+  // Messages must kick watchdog every FAULT_CYCLES, otherwise trigger fault
+  uint8_t watching[WATCHDOG_MAX_FAULTS];
+  uint8_t num_watching;
+
+  uint8_t missed_cycles[WATCHDOG_MAX_FAULTS];
+
+  FaultHandler handler;
+
+} FaultStorage;
+
+StatusCode fault_init(FaultStorage *storage);

--- a/libraries/ms-common/src/fault.c
+++ b/libraries/ms-common/src/fault.c
@@ -1,0 +1,54 @@
+#include "fault.h"
+
+#include "delay.h"
+#include "log.h"
+#include "semphr.h"
+#include "status.h"
+#include "tasks.h"
+
+#define FAULT_CYCLES 5
+
+static FaultStorage *s_storage;
+
+static uint8_t s_max_cycles_missed;
+static uint32_t s_cycles_missed_bitset;
+
+TASK(fault, TASK_MIN_STACK_SIZE) {
+  bool fault = false;
+  s_max_cycles_missed = 0;
+
+  while (true) {
+    if (!fault) {
+      // Check faults
+      for (uint8_t i = 0; i < s_storage->num_faults; i++) {
+        if (s_storage->faults[i]) {
+          fault = true;
+        }
+      }
+
+      // Check all messages for timeout
+      for (uint8_t i = 0; i < s_storage->num_faults; i++) {
+        // If a message has not been received
+        if (!s_storage->watching[i]) {
+          s_storage->missed_cycles[i]++;
+          if (s_storage->missed_cycles[i] > FAULT_CYCLES) {
+            fault = true;
+          }
+        } else {
+          s_storage->missed_cycles[i] = 0;
+        }
+      }
+
+      // Delay until next check cycle
+      delay_ms(100);
+    } else {
+      s_storage->handler();
+    }
+  }
+}
+
+StatusCode fault_init(FaultStorage *storage) {
+  s_storage = storage;
+  status_ok_or_return(tasks_init_task(fault, TASK_PRIORITY(4), NULL));
+  return STATUS_CODE_OK;
+}

--- a/projects/bms_carrier/src/fault_bps.c
+++ b/projects/bms_carrier/src/fault_bps.c
@@ -1,6 +1,7 @@
 #include "fault_bps.h"
 
 #include "bms.h"
+#include "bms_carrier_setters.h"
 #include "exported_enums.h"
 
 static BmsStorage *s_storage;
@@ -13,15 +14,16 @@ StatusCode fault_bps_init(BmsStorage *storage) {
 // TODO: These faulting mechanism will be changing substantially
 // Fault BPS and open relays
 StatusCode fault_bps_set(uint8_t fault_bitmask) {
-  // s_storage->bps_storage.fault_bitset |= fault_bitmask;
-  // if (fault_bitmask != EE_BPS_STATE_FAULT_RELAY) {
-  //   relay_fault(&s_storage->relay_storage);
-  // }
+  if (fault_bitmask != EE_BPS_STATE_FAULT_RELAY) {
+    set_bps_heartbeat_status(g_tx_struct.bps_heartbeat_status | fault_bitmask);
+  } else {
+    // Handle opening relays
+  }
   return STATUS_CODE_OK;
 }
 
 // Clear fault from fault_bitmask
 StatusCode fault_bps_clear(uint8_t fault_bitmask) {
-  // s_storage->bps_storage.fault_bitset &= ~(fault_bitmask);
+  set_bps_heartbeat_status(g_tx_struct.bps_heartbeat_status & ~(fault_bitmask));
   return STATUS_CODE_OK;
 }

--- a/smoke/fault/README.md
+++ b/smoke/fault/README.md
@@ -1,0 +1,16 @@
+<!--
+    General guidelines
+    These are just guidelines, not strict rules - document however seems best.
+    A README for a firmware-only project (e.g. Babydriver, MPXE, bootloader, CAN explorer) should answer the following questions:
+        - What is it?
+        - What problem does it solve?
+        - How do I use it? (with usage examples / example commands, etc)
+        - How does it work? (architectural overview)
+    A README for a board project (powering a hardware board, e.g. power distribution, centre console, charger, BMS carrier) should answer the following questions:
+        - What is the purpose of the board?
+        - What are all the things that the firmware needs to do?
+        - How does it fit into the overall system?
+        - How does it work? (architectural overview, e.g. what each module's purpose is or how data flows through the firmware)
+-->
+# fault
+

--- a/smoke/fault/config.json
+++ b/smoke/fault/config.json
@@ -1,0 +1,6 @@
+{
+    "libs": [
+        "FreeRTOS",
+        "ms-common"
+    ]
+}

--- a/smoke/fault/src/main.c
+++ b/smoke/fault/src/main.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdint.h>
+
+#include "fault.h"
+
+#include "log.h"
+#include "tasks.h"
+#include "master_task.h"
+#include "delay.h"
+// #include "centre_console_getters.h" <- not getting included for some reason
+
+void run_fast_cycle()
+{
+
+}
+
+void run_medium_cycle()
+{
+
+}
+
+void run_slow_cycle()
+{
+
+}
+
+void fault_handler() {
+   LOG_DEBUG("IN FAULT HANDLER\n");
+   non_blocking_delay_ms(100);
+}
+
+TASK(master_task, TASK_STACK_512) {
+  while (true) {
+   run_fast_cycle();
+   delay_ms(50);
+  }
+}
+
+int main() {
+   tasks_init();
+   log_init();
+   LOG_DEBUG("Welcome to TEST!");
+
+   FaultStorage storage = {
+      // Watch critical faults
+      // If any of these are non-zero, the fault task takes over the ECU and
+      // will require a power cycle
+      .faults = {
+         1, // get_solar_fault_5_mppts_fault(),
+         2, // get_solar_fault_6_mppts_fault()
+      },
+      .num_faults = 2,
+
+      // Watch critical messages
+      // If any of these are not received in FAULT_CYCLES, the fault task takes over the ECU and
+      // will require a power cycle
+      .watching = {
+         0, // get_received_solar_fault_5_mppts(),
+         0, // get_received_solar_fault_6_mppts(),
+         0, // get_received_battery_relay_state()
+      },
+
+      .num_watching = 3,
+      .handler = fault_handler
+   };
+
+   fault_init(&storage);
+
+   tasks_init_task(master_task, TASK_PRIORITY(2), NULL);
+
+   tasks_start();
+
+   LOG_DEBUG("exiting main?");
+   return 0;
+}
+


### PR DESCRIPTION
We were discussing how we wanted to add fault behaviour and I thought this was a good option. This task basically will just take over if its "watchdog" fails. The handler is defined per project and passed as a function pointer. I thought this was needed since BMS/CC/MCI etc. all need to do different things and the main thing that can be made into a module is this task.

If we need more granularity like monitoring a GPIO I could prob add that into this as well but lmk what u think

Still gotta actually add the BMS behaviour but it would essentially just be a list of messages. (Ill delete the smoke test after review)